### PR TITLE
Use pixelated canvas rendering instead of default browser scaling

### DIFF
--- a/src/x-nes.css
+++ b/src/x-nes.css
@@ -54,6 +54,23 @@
 }
 
 /**
+ * Check if the browser supports pixelated image-rendering
+ */
+@supports not(image-rendering: pixelated) {
+	.nes-fullscreen canvas {
+		image-rendering: -moz-crisp-edges;
+		image-rendering: -webkit-crisp-edges;
+		image-rendering: crisp-edges
+	}
+}
+
+@supports (image-rendering: pixelated) {
+	.nes-fullscreen canvas {
+		image-rendering: pixelated
+	}
+}
+
+/**
  * Emulator video output should always scale to dimensions of parent, 
  * while retaining aspect ratio.
  */

--- a/src/x-nes.css
+++ b/src/x-nes.css
@@ -56,7 +56,7 @@
 /**
  * Check if the browser supports pixelated image-rendering
  */
-@supports not(image-rendering: pixelated) {
+@supports not (image-rendering: pixelated) {
 	.nes-fullscreen canvas {
 		image-rendering: -moz-crisp-edges;
 		image-rendering: -webkit-crisp-edges;


### PR DESCRIPTION
NES games are pixelated and therefore should not be dependent on the browser's image scaling settings. This forces crisp images in full screen.
If a browser supports `image-rendering: pixelated`, `pixelated` is used. If it doesn't, it falls back on prefixed `crisp-edges` values.
